### PR TITLE
Correct rounding for high resolution

### DIFF
--- a/videokit/src/main/java/com/groupme/android/videokit/VideoTranscoder.java
+++ b/videokit/src/main/java/com/groupme/android/videokit/VideoTranscoder.java
@@ -902,8 +902,8 @@ public class VideoTranscoder {
 
     private int getRoundedSize(float ratio, int size) {
         // The transcoder can fail if the resolution isn't a multiple of 2. So, round it if not.
-        int adjusted = (int) ratio * size;
-        return (adjusted + 1) / 2;
+        int adjusted = (int) (ratio * size);
+        return Math.round(adjusted / 4) * 2;
     }
 
 


### PR DESCRIPTION
For high resolutions, ratio was rounded to 0 with `(int) ratio` making width/height = 0. This caused errors on line 935 `MediaFormat.createVideoFormat(
                Defaults.OUTPUT_VIDEO_MIME_TYPE, mOutputVideoWidth, mOutputVideoHeight)`

After fixing the 0 width/height, the rounded size was still not a guarantee to be a multiple of 2, so added more rounding logic here.