### PR TITLE
Increase height of toggle switch view so the switch isn't cut off

### DIFF
--- a/videokit/build.gradle
+++ b/videokit/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "28.0.3"
+    compileSdkVersion 30
+    buildToolsVersion "30.0.3"
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
     }

--- a/videokit/src/main/java/com/android/gallery3d/app/CommonControllerOverlay.java
+++ b/videokit/src/main/java/com/android/gallery3d/app/CommonControllerOverlay.java
@@ -226,10 +226,7 @@ public abstract class CommonControllerOverlay extends FrameLayout implements
     }
     @Override
     public boolean onTouchEvent(MotionEvent event) {
-        if (super.onTouchEvent(event)) {
-            return true;
-        }
-        return false;
+        return super.onTouchEvent(event);
     }
     // The paddings of 4 sides which covered by system components. E.g.
     // +-----------------+\

--- a/videokit/src/main/java/com/android/gallery3d/app/CommonControllerOverlay.java
+++ b/videokit/src/main/java/com/android/gallery3d/app/CommonControllerOverlay.java
@@ -117,12 +117,13 @@ public abstract class CommonControllerOverlay extends FrameLayout implements
         mToggleSwitch = new Switch(context);
         mToggleSwitch.setTextColor(getResources().getColor(R.color.white));
         mToggleSwitch.setTextSize(16);
+        mToggleSwitch.setMinimumHeight(64);
         ColorStateList trackColor = ColorStateList.valueOf(getResources().getColor(R.color.white));
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             mToggleSwitch.setTrackTintList(trackColor);
         }
         mToggleSwitchView.addView(mToggleSwitch, wrapContent);
-        mToggleSwitchView.setMinimumHeight(64);
+        mToggleSwitchView.setMinimumHeight(mToggleSwitch.getMinimumHeight() + 8);
         addView(mToggleSwitchView, matchParent);
         hide();
     }

--- a/videokit/src/main/java/com/android/gallery3d/app/TimeBar.java
+++ b/videokit/src/main/java/com/android/gallery3d/app/TimeBar.java
@@ -26,6 +26,8 @@ import android.view.View;
 
 import com.groupme.android.videokit.R;
 
+import java.util.Locale;
+
 /**
  * The time bar view, which includes the current and total time, the progress
  * bar, and the scrubber.
@@ -41,7 +43,7 @@ public class TimeBar extends View {
     // The total padding, top plus bottom
     private static final int V_PADDING_IN_DP = 30;
     private static final int TEXT_SIZE_IN_DP = 14;
-    protected final Listener mListener;
+    protected Listener mListener;
     // the bars we use for displaying the progress
     protected final Rect mProgressBar;
     protected final Rect mPlayedBar;
@@ -61,9 +63,9 @@ public class TimeBar extends View {
     protected int mCurrentTime;
     protected final Rect mTimeBounds;
     protected int mVPaddingInPx;
-    public TimeBar(Context context, Listener listener) {
+
+    TimeBar(Context context) {
         super(context);
-        mListener = checkNotNull(listener);
         mShowTimes = true;
         mShowScrubber = true;
         mProgressBar = new Rect();
@@ -83,6 +85,10 @@ public class TimeBar extends View {
         mScrubber = BitmapFactory.decodeResource(getResources(), R.drawable.play_scrubber);
         mScrubberPadding = (int) (metrics.density * SCRUBBER_PADDING_IN_DP);
         mVPaddingInPx = (int) (metrics.density * V_PADDING_IN_DP);
+    }
+    public TimeBar(Context context, Listener listener) {
+        this(context);
+        mListener = checkNotNull(listener);
     }
     private void update() {
         mPlayedBar.set(mProgressBar);
@@ -165,13 +171,13 @@ public class TimeBar extends View {
         if (mShowTimes) {
             canvas.drawText(
                     stringForTime(mCurrentTime),
-                            mTimeBounds.width() / 2 + getPaddingLeft(),
-                            mTimeBounds.height() + mVPaddingInPx / 2 + mScrubberPadding + 1,
+                            mTimeBounds.width() / 2f + getPaddingLeft(),
+                            mTimeBounds.height() + mVPaddingInPx / 2f + mScrubberPadding + 1,
                     mTimeTextPaint);
             canvas.drawText(
                     stringForTime(mTotalTime),
                             getWidth() - getPaddingRight() - mTimeBounds.width() / 2,
-                            mTimeBounds.height() + mVPaddingInPx / 2 + mScrubberPadding + 1,
+                            mTimeBounds.height() + mVPaddingInPx / 2f + mScrubberPadding + 1,
                     mTimeTextPaint);
         }
     }
@@ -213,9 +219,9 @@ public class TimeBar extends View {
         int minutes = (totalSeconds / 60) % 60;
         int hours = totalSeconds / 3600;
         if (hours > 0) {
-            return String.format("%d:%02d:%02d", hours, minutes, seconds).toString();
+            return String.format(Locale.US, "%d:%02d:%02d", hours, minutes, seconds);
         } else {
-            return String.format("%02d:%02d", minutes, seconds).toString();
+            return String.format(Locale.US, "%02d:%02d", minutes, seconds);
         }
     }
     public void setSeekable(boolean canSeek) {

--- a/videokit/src/main/java/com/android/gallery3d/app/TrimControllerOverlay.java
+++ b/videokit/src/main/java/com/android/gallery3d/app/TrimControllerOverlay.java
@@ -18,7 +18,6 @@ import android.animation.Animator;
 import android.animation.Animator.AnimatorListener;
 import android.animation.ObjectAnimator;
 import android.content.Context;
-import android.os.Build;
 import android.view.MotionEvent;
 import android.view.View;
 
@@ -28,8 +27,12 @@ import com.swiftkey.cornedbeef.BubbleCoachMark;
  * The controller for the Trimming Video.
  */
 public class TrimControllerOverlay extends CommonControllerOverlay  {
-    public TrimControllerOverlay(Context context, int maxDuration) {
+
+    TrimControllerOverlay(Context context) {
         super(context);
+    }
+    public TrimControllerOverlay(Context context, int maxDuration) {
+        this(context);
         ((TrimTimeBar) mTimeBar).setMaxDuration(maxDuration);
     }
     @Override
@@ -40,9 +43,7 @@ public class TrimControllerOverlay extends CommonControllerOverlay  {
         if (mState == State.PLAYING) {
             mPlayPauseReplayView.setVisibility(View.INVISIBLE);
         }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-            mPlayPauseReplayView.setAlpha(1f);
-        }
+        mPlayPauseReplayView.setAlpha(1f);
     }
     public void hideToggle() {
         mToggleSwitchView.setVisibility(View.GONE);
@@ -50,10 +51,6 @@ public class TrimControllerOverlay extends CommonControllerOverlay  {
 
     public void showToggle() {
         mToggleSwitchView.setVisibility(View.VISIBLE);
-    }
-
-    public boolean getToggleState() {
-        return mToggleSwitch.isChecked();
     }
 
     public void setMaxDuration(int maxDuration) {
@@ -75,30 +72,26 @@ public class TrimControllerOverlay extends CommonControllerOverlay  {
     @Override
     public void showPlaying() {
         super.showPlaying();
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-            // Add animation to hide the play button while playing.
-            ObjectAnimator anim = ObjectAnimator.ofFloat(mPlayPauseReplayView, "alpha", 1f, 0f);
-            anim.setDuration(200);
-            anim.start();
-            anim.addListener(new AnimatorListener() {
-                @Override
-                public void onAnimationStart(Animator animation) {
-                }
-                @Override
-                public void onAnimationEnd(Animator animation) {
-                    hidePlayButtonIfPlaying();
-                }
-                @Override
-                public void onAnimationCancel(Animator animation) {
-                    hidePlayButtonIfPlaying();
-                }
-                @Override
-                public void onAnimationRepeat(Animator animation) {
-                }
-            });
-        } else {
-            hidePlayButtonIfPlaying();
-        }
+        // Add animation to hide the play button while playing.
+        ObjectAnimator anim = ObjectAnimator.ofFloat(mPlayPauseReplayView, "alpha", 1f, 0f);
+        anim.setDuration(200);
+        anim.start();
+        anim.addListener(new AnimatorListener() {
+            @Override
+            public void onAnimationStart(Animator animation) {
+            }
+            @Override
+            public void onAnimationEnd(Animator animation) {
+                hidePlayButtonIfPlaying();
+            }
+            @Override
+            public void onAnimationCancel(Animator animation) {
+                hidePlayButtonIfPlaying();
+            }
+            @Override
+            public void onAnimationRepeat(Animator animation) {
+            }
+        });
     }
     @Override
     public void setTimes(int currentTime, int totalTime, int trimStartTime, int trimEndTime) {

--- a/videokit/src/main/java/com/android/gallery3d/app/TrimTimeBar.java
+++ b/videokit/src/main/java/com/android/gallery3d/app/TrimTimeBar.java
@@ -22,8 +22,6 @@ import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Rect;
-import android.util.DisplayMetrics;
-import android.util.Log;
 import android.view.MotionEvent;
 
 import com.groupme.android.videokit.R;
@@ -58,8 +56,8 @@ public class TrimTimeBar extends TimeBar {
     private final Bitmap mTrimEndScrubber;
     private int mMaxDuration;
     private int mProgressY;
-    private Rect mSelectionBar;
-    private int mMinDuration = 1 * 1000; // 1 second
+    private final Rect mSelectionBar;
+    private final int mMinDuration = 1000; // 1 second
 
     public TrimTimeBar(Context context, Listener listener) {
         super(context, listener);
@@ -192,8 +190,7 @@ public class TrimTimeBar extends TimeBar {
                 margin += mTimeBounds.width();
             }
             mProgressY = h / 2;
-            int scrubberY = mProgressY - mScrubber.getHeight() / 2 + 1;
-            mScrubberTop = scrubberY;
+            mScrubberTop = mProgressY - mScrubber.getHeight() / 2 + 1;
             mTrimStartScrubberTop = mProgressY - mTrimStartScrubber.getHeight() / 2 + 1;
             mTrimEndScrubberTop = mProgressY - mTrimEndScrubber.getHeight() / 2 + 1;
             mProgressBar.set(
@@ -213,13 +210,13 @@ public class TrimTimeBar extends TimeBar {
         if (mShowTimes) {
             canvas.drawText(
                     stringForTime(mCurrentTime),
-                            mTimeBounds.width() / 2 + getPaddingLeft(),
-                            mTimeBounds.height() / 2 +  mProgressY,
+                            mTimeBounds.width() / 2f + getPaddingLeft(),
+                            mTimeBounds.height() / 2f +  mProgressY,
                     mTimeTextPaint);
             canvas.drawText(
                     stringForTime(mTotalTime),
-                            getWidth() - getPaddingRight() - mTimeBounds.width() / 2,
-                            mTimeBounds.height() / 2 +  mProgressY,
+                            getWidth() - getPaddingRight() - mTimeBounds.width() / 2f,
+                            mTimeBounds.height() / 2f +  mProgressY,
                     mTimeTextPaint);
         }
 
@@ -264,7 +261,7 @@ public class TrimTimeBar extends TimeBar {
                             mScrubberCorrection = x - mTrimEndScrubberLeft;
                             break;
                     }
-                    if (mScrubbing == true) {
+                    if (mScrubbing) {
                         mListener.onScrubbingStart();
                         return true;
                     }

--- a/videokit/src/main/java/com/android/gallery3d/app/TrimVideo.java
+++ b/videokit/src/main/java/com/android/gallery3d/app/TrimVideo.java
@@ -36,7 +36,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
-import android.widget.CompoundButton;
 import android.widget.TextView;
 import android.widget.Toast;
 import android.widget.VideoView;
@@ -61,7 +60,6 @@ public class TrimVideo extends Activity implements
     private int mMaxDuration = 30 * 1000; // 30 seconds
     private VideoView mVideoView;
     private TrimControllerOverlay mController;
-    private Context mContext;
     private Uri mUri;
     private final Handler mHandler = new Handler();
     public ProgressDialog mProgress;
@@ -118,7 +116,7 @@ public class TrimVideo extends Activity implements
     @Override
     public void onCreate(Bundle savedInstanceState) {
         try {
-            mContext = getApplicationContext();
+            Context context = getApplicationContext();
             super.onCreate(savedInstanceState);
             requestWindowFeature(Window.FEATURE_ACTION_BAR);
             requestWindowFeature(Window.FEATURE_ACTION_BAR_OVERLAY);
@@ -146,7 +144,7 @@ public class TrimVideo extends Activity implements
             setContentView(R.layout.trim_view);
             View rootView = findViewById(R.id.trim_view_root);
             mVideoView = (VideoView) rootView.findViewById(R.id.surface_view);
-            mController = new TrimControllerOverlay(mContext, mMaxDuration);
+            mController = new TrimControllerOverlay(context, mMaxDuration);
             ((ViewGroup) rootView).addView(mController.getView());
             mController.setListener(this);
             mController.setCanReplay(true);
@@ -156,7 +154,7 @@ public class TrimVideo extends Activity implements
             if (ContentResolver.SCHEME_FILE.equals(mUri.getScheme())) {
                 retriever.setDataSource(mUri.getPath());
             } else {
-                retriever.setDataSource(mContext, mUri);
+                retriever.setDataSource(context, mUri);
             }
 
             mDuration = Integer.parseInt(retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION));
@@ -181,11 +179,7 @@ public class TrimVideo extends Activity implements
                     } else {
                         mMaxDuration = getIntent().getIntExtra(EXTRA_MAX_DURATION, mMaxDuration);
                     }
-                    if(mTrimStartTime + mMaxDuration > mDuration) {
-                        mTrimEndTime = mDuration;
-                    } else {
-                        mTrimEndTime = mTrimStartTime + mMaxDuration;
-                    }
+                    mTrimEndTime = Math.min(mTrimStartTime + mMaxDuration, mDuration);
                     mController.setMaxDuration(mMaxDuration);
                     mController.setTimes(mTrimStartTime, mDuration, mTrimStartTime, mTrimEndTime);
                 });

--- a/videokit/src/main/java/com/groupme/android/videokit/support/Component.java
+++ b/videokit/src/main/java/com/groupme/android/videokit/support/Component.java
@@ -1,17 +1,14 @@
 package com.groupme.android.videokit.support;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.media.MediaExtractor;
 import android.media.MediaFormat;
 import android.net.Uri;
-import android.os.Build;
 
 import com.groupme.android.videokit.util.MediaInfo;
 
 import java.io.IOException;
 
-@TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
 public class Component {
     public static int COMPONENT_TYPE_AUDIO = 0;
     public static int COMPONENT_TYPE_VIDEO = 1;
@@ -28,10 +25,10 @@ public class Component {
 
     /**
      *
-     * @param context
-     * @param srcUri
-     * @param type
-     * @throws IOException
+     * @param context Context that this component is in
+     * @param srcUri Source uri for the component
+     * @param type Type of component - either audio or video
+     * @throws IOException Thrown if the component type is invalid
      */
     public Component(Context context, Uri srcUri, int type) throws IOException {
         mContext = context;
@@ -47,32 +44,28 @@ public class Component {
     }
 
     /**
-     * The MediaExtractor instance to use to for this component.
-     * @return
+     * @return The MediaExtractor instance to use to for this component.
      */
     public MediaExtractor getMediaExtractor() {
         return mMediaExtractor;
     }
 
     /**
-     * The MediaFormat for the selected track of this component.
-     * @return
+     * @return The MediaFormat for the selected track of this component.
      */
     public MediaFormat getTrackFormat() {
         return mTrackFormat;
     }
 
     /**
-     * The index of the selected track for this component.
-     * @return
+     * @return The index of the selected track for this component.
      */
     public int getSelectedTrackIndex() {
         return mSelectedTrackIndex;
     }
 
     /**
-     * The component type.
-     * @return COMPONENT_TYPE_AUDIO or COMPONENT_TYPE_VIDEO
+     * @return The component type. Either COMPONENT_TYPE_AUDIO or COMPONENT_TYPE_VIDEO
      */
     public int getType() {
         return mType;
@@ -86,7 +79,7 @@ public class Component {
 
     /**
      * create me!
-     * @throws IOException
+     * @throws IOException If unable to create this component
      */
     private void init() throws IOException {
         createExtractor();
@@ -96,7 +89,7 @@ public class Component {
     /**
      * Creates an extractor that reads its frames from {@link #mSrcUri}
      *
-     * @throws java.io.IOException
+     * @throws IOException If unable to create a media extractor for this component
      */
     private void createExtractor() throws IOException {
         mMediaExtractor = new MediaExtractor();

--- a/videokit/src/main/java/com/groupme/android/videokit/support/InputSurface.java
+++ b/videokit/src/main/java/com/groupme/android/videokit/support/InputSurface.java
@@ -16,14 +16,12 @@
 
 package com.groupme.android.videokit.support;
 
-import android.annotation.TargetApi;
 import android.opengl.EGL14;
 import android.opengl.EGLExt;
 import android.opengl.EGLConfig;
 import android.opengl.EGLContext;
 import android.opengl.EGLDisplay;
 import android.opengl.EGLSurface;
-import android.util.Log;
 import android.view.Surface;
 
 
@@ -34,7 +32,6 @@ import android.view.Surface;
  * to create an EGL window surface.  Calls to eglSwapBuffers() cause a frame of data to be sent
  * to the video encoder.
  */
-@TargetApi(17)
 public class InputSurface {
     private static final String TAG = "InputSurface";
 

--- a/videokit/src/main/java/com/groupme/android/videokit/support/OutputSurface.java
+++ b/videokit/src/main/java/com/groupme/android/videokit/support/OutputSurface.java
@@ -53,7 +53,7 @@ public class OutputSurface implements SurfaceTexture.OnFrameAvailableListener {
     private SurfaceTexture mSurfaceTexture;
     private Surface mSurface;
 
-    private Object mFrameSyncObject = new Object();     // guards mFrameAvailable
+    private final Object mFrameSyncObject = new Object();     // guards mFrameAvailable
     private boolean mFrameAvailable;
 
     private TextureRender mTextureRender;
@@ -252,7 +252,7 @@ public class OutputSurface implements SurfaceTexture.OnFrameAvailableListener {
 
     /**
      * Wait up to given timeout until new image become available.
-     * @param timeoutMs
+     * @param timeoutMs The amount of time to wait in milliseconds
      * @return true if new image is available. false for no new image until timeout.
      */
     public boolean checkForNewImage(int timeoutMs) {

--- a/videokit/src/main/java/com/groupme/android/videokit/support/TextureRender.java
+++ b/videokit/src/main/java/com/groupme/android/videokit/support/TextureRender.java
@@ -16,14 +16,12 @@
 
 package com.groupme.android.videokit.support;
 
-import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 
-import android.annotation.TargetApi;
 import android.graphics.Bitmap;
 import android.graphics.SurfaceTexture;
 import android.opengl.GLES11Ext;
@@ -36,7 +34,6 @@ import android.util.Log;
  * Code for rendering a texture onto a surface using OpenGL ES 2.0.
  */
 
-@TargetApi(11)
 public class TextureRender {
     private static final String TAG = "TextureRender";
 
@@ -52,7 +49,7 @@ public class TextureRender {
          1.0f,  1.0f, 0, 1.f, 1.f,
     };
 
-    private FloatBuffer mTriangleVertices;
+    private final FloatBuffer mTriangleVertices;
 
     private static final String VERTEX_SHADER =
             "uniform mat4 uMVPMatrix;\n" +
@@ -74,8 +71,8 @@ public class TextureRender {
             "  gl_FragColor = texture2D(sTexture, vTextureCoord);\n" +
             "}\n";
 
-    private float[] mMVPMatrix = new float[16];
-    private float[] mSTMatrix = new float[16];
+    private final float[] mMVPMatrix = new float[16];
+    private final float[] mSTMatrix = new float[16];
 
     private int mProgram;
     private int mTextureID = -12345;
@@ -254,7 +251,7 @@ public class TextureRender {
      * <p>
      * Useful for debugging.
      */
-    public static void saveFrame(String filename, int width, int height) {
+    public static void saveFrame(String filename, int width, int height) throws RuntimeException {
         // glReadPixels gives us a ByteBuffer filled with what is essentially big-endian RGBA
         // data (i.e. a byte of red, followed by a byte of green...).  We need an int[] filled
         // with native-order ARGB data to feed to Bitmap.

--- a/videokit/src/main/java/com/groupme/android/videokit/util/MediaInfo.java
+++ b/videokit/src/main/java/com/groupme/android/videokit/util/MediaInfo.java
@@ -1,6 +1,5 @@
 package com.groupme.android.videokit.util;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.media.MediaExtractor;
 import android.media.MediaFormat;
@@ -9,14 +8,10 @@ import android.net.Uri;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-@TargetApi(16)
 public class MediaInfo {
-    public static int VALUE_NOT_AVAILABLE = -1;
 
     private final Context mContext;
     private final Uri mMediaUri;
-
-    private MediaExtractor mMediaExtractor;
 
     private MediaFormat mAudioTrackFormat;
     private MediaFormat mVideoTrackFormat;
@@ -53,8 +48,7 @@ public class MediaInfo {
     }
 
     /**
-     * Returns the track duration in seconds.
-     * @return
+     * @return The track duration in seconds
      */
     public long getDuration() {
         long duration = -1;
@@ -85,12 +79,12 @@ public class MediaInfo {
     }
 
     private void extract() throws IOException {
-        mMediaExtractor = new MediaExtractor();
-        mMediaExtractor.setDataSource(mContext, mMediaUri, null);
+        MediaExtractor mediaExtractor = new MediaExtractor();
+        mediaExtractor.setDataSource(mContext, mMediaUri, null);
 
-        int trackCount = mMediaExtractor.getTrackCount();
+        int trackCount = mediaExtractor.getTrackCount();
         for (int i = 0; i < trackCount; i++) {
-            MediaFormat track = mMediaExtractor.getTrackFormat(i);
+            MediaFormat track = mediaExtractor.getTrackFormat(i);
 
             if (isAudioFormat(track)) {
                 mAudioTrackFormat = track;


### PR DESCRIPTION
The toggle switch was being cut off because the minimum height set for the view wrapping it was smaller than the height of the switch itself. Fixed this by making the view height dependent on the minimum height of the switch.